### PR TITLE
feat: add support for other container cli

### DIFF
--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -24,7 +24,7 @@ USAGE
   c8y tedge bootstrap-container <CONTAINER> [DEVICE_ID]
 
 ARGUMENTS
-  CONTAINER           Container name, e.g. tedge
+  CONTAINER           Container name or compose service name, e.g. tedge
   DEVICE_ID           Device id to be assigned to the device. This will only be used if the device
                       has not already been bootstrapped. If one is not given, then a random name will be assigned
 

--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -6,6 +6,7 @@ OPEN_WEBSITE=1
 WEBSITE_PAGE="device-info"
 SCAN=${SCAN:-0}
 PATTERN="${PATTERN:-.+}"
+C8Y_TEDGE_CONTAINER_CLI="${C8Y_TEDGE_CONTAINER_CLI:-}"
 
 usage() {
     EXAMPLES=$(examples 2>&1)
@@ -28,11 +29,12 @@ ARGUMENTS
                       has not already been bootstrapped. If one is not given, then a random name will be assigned
 
 FLAGS
-  --skip-website      Don't open the Cumulocity IoT Device Management application
-  --page <STRING>     Which Device Management page to open. Defaults to device-info
-  --verbose           Enable verbose logging
-  --debug             Enable debug logging
-  -h, --help          Show this help
+  --container-cli <STRING>    Container cli, e.g. docker, nerdctl, podman. Can also be set via the environment variable, C8Y_TEDGE_CONTAINER_CLI
+  --skip-website              Don't open the Cumulocity IoT Device Management application
+  --page <STRING>             Which Device Management page to open. Defaults to device-info
+  --verbose                   Enable verbose logging
+  --debug                     Enable debug logging
+  -h, --help                  Show this help
 
 $EXAMPLES
 
@@ -49,8 +51,15 @@ c8y tedge bootstrap-container container01
 # Bootstrap a container using using a given device id
 c8y tedge bootstrap-container container01 customname_001
 
-# Bootstrap a device via ssh but don't open the website
+# Bootstrap a device but don't open the website
 c8y tedge bootstrap-container container01 --skip-website
+
+# Bootstrap a device using podman 
+c8y tedge bootstrap-container container01 --container-cli podman
+
+# Bootstrap a device using nerdctl (by setting an environment variable)
+export C8Y_TEDGE_CONTAINER_CLI=nerdctl
+c8y tedge bootstrap-container container01
 
 EOT
 }
@@ -76,6 +85,10 @@ while [ $# -gt 0 ]; do
             DEVICE_ID="$2"
             shift
             ;;
+        --container-cli)
+            C8Y_TEDGE_CONTAINER_CLI="$2"
+            shift
+            ;;
         --skip-website)
             OPEN_WEBSITE=0
             ;;
@@ -96,18 +109,37 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+# Try auto detecting container cli (based on what is available)
+if [ -z "$C8Y_TEDGE_CONTAINER_CLI" ]; then
+    if command -V docker >/dev/null 2>&1; then
+        C8Y_TEDGE_CONTAINER_CLI=docker
+    elif command -V nerdctl >/dev/null 2>&1; then
+        C8Y_TEDGE_CONTAINER_CLI=nerdctl
+    elif command -V podman >/dev/null 2>&1; then
+        C8Y_TEDGE_CONTAINER_CLI=podman
+    fi
+fi
+
+if [ -z "$C8Y_TEDGE_CONTAINER_CLI" ]; then
+    echo "Error: Could not find a container cli, e.g. docker, nerdctl, podman" >&2
+    exit 1
+fi
+
+echo "Using container cli: $C8Y_TEDGE_CONTAINER_CLI" >&2
+
 # Default to docker
 EXEC_CMD=(
-    docker
+    "$C8Y_TEDGE_CONTAINER_CLI"
     exec
 )
 
 # Auto detect a local docker-compose file and use the service name instead
 if [ -f docker-compose.yaml ] || [ -f docker-compose.yml ]; then
     EXEC_CMD=(
-        docker
+        "$C8Y_TEDGE_CONTAINER_CLI"
         compose
         exec
+        --no-TTY
     )
 fi
 


### PR DESCRIPTION
New flag (`--container-cli <CLI_COMMAND>`) which can be used to control which container cli is used to run the exec commands.

The container-cli can also be set via the `C8Y_TEDGE_CONTAINER_CLI` environment variable, which allows you to save your preference in your shell profile.

If the container-cli is not provided, then a best guess will be done and the first found cli command will be used, the order is:
* docker
* nerdctl
* podman

**Examples**

```sh
# Bootstrap a device using podman 
c8y tedge bootstrap-container container01 --container-cli podman

# Bootstrap a device using nerdctl (by setting an environment variable)
export C8Y_TEDGE_CONTAINER_CLI=nerdctl
c8y tedge bootstrap-container container01
```