### PR TITLE
feat: wait for container to be ready before bootstrapping

### DIFF
--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -140,6 +140,12 @@ EXEC_CMD=(
     "$C8Y_TEDGE_CONTAINER_CLI"
     exec
 )
+CHECK_CMD=(
+    "$C8Y_TEDGE_CONTAINER_CLI"
+    ps
+    -a
+    --format '{{.State}}'
+)
 
 # Auto detect a local docker-compose file and use the service name instead
 if [ -f docker-compose.yaml ] || [ -f docker-compose.yml ]; then
@@ -149,7 +155,50 @@ if [ -f docker-compose.yaml ] || [ -f docker-compose.yml ]; then
         exec
         --no-TTY
     )
+    CHECK_CMD=(
+        "$C8Y_TEDGE_CONTAINER_CLI"
+        compose
+        ps
+        -a
+        --format '{{.State}}'
+    )
 fi
+
+wait_for_container() {
+    # Wait for container to be ready (or skip if it has already exited)
+    container_name="$1"
+    COUNTER=1
+    TIMEOUT=60
+    BOOTSTRAP=1
+
+    DONE=0
+    while [ "$DONE" -eq 0 ]; do
+        
+        state="$("${CHECK_CMD[@]}" "$container_name")"
+        case "$state" in
+            running)
+                DONE=1
+                ;;
+            exited)
+                DONE=1
+                BOOTSTRAP=0
+                # echo "tedge service is already running (bootstrapping was probably already done)" >&2
+                ;;
+            *)
+                if [ "$COUNTER" -gt "$TIMEOUT" ]; then
+                    DONE=0
+                    BOOTSTRAP=2
+                    break
+                fi
+
+                echo "$container_name is not yet running...attempt $COUNTER of $TIMEOUT" >&2
+                sleep 1
+                COUNTER=$((COUNTER + 1))
+                ;;
+        esac
+    done
+    echo "$BOOTSTRAP"
+}
 
 
 do_action() {
@@ -170,6 +219,22 @@ do_action() {
     else
         URL=$(c8y sessions get --select host -o csv | sed -E 's|https?://||')
     fi
+
+    container_result=$(wait_for_container "$TARGET")
+    case "$container_result" in
+        0)
+            echo "Container has already been bootstrapped" >&2
+            exit 0
+            ;;
+        1)
+            echo "Container ($TARGET) is ready for bootstrapping" >&2
+            ;;
+        *)
+            echo "Timed out waiting for bootstrap service to be ready" >&2
+            exit 1
+            ;;
+    esac
+
     "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"
 
     # Create the device certificate, ignore any errors as this could have already happened


### PR DESCRIPTION
Wait for the container to be ready before trying to bootstrap it. Also check if the container has already been bootstrapped, and exit cleanly if so.