### PR TITLE
feat(bootstrap): Support bootstrapping using a local ca

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -349,6 +349,16 @@ do_action() {
     else
         URL=$(c8y sessions get --select host -o csv | sed -E 's|https?://||')
     fi
+
+    # Disconnect if tedge is already connected
+    # Note: Check if the mapper is configured or not but it can't be assumed that it is successfully configured
+    EXISTING_C8Y_URL=$("${EXEC_CMD[@]}" "$TARGET" tedge config get c8y.url 2>/dev/null)
+    if [ -n "$EXISTING_C8Y_URL" ]; then
+        # TODO: Add option to abort if already bootstrapped (to prevent accidental)
+        echo "tedge is already connected, so disconnecting before bootstrapping" >&2
+        "${EXEC_CMD[@]}" "$TARGET" tedge disconnect c8y ||:
+    fi
+
     "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"
 
     # Get identity

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -357,6 +357,13 @@ do_action() {
         # TODO: Add option to abort if already bootstrapped (to prevent accidental)
         echo "tedge is already connected, so disconnecting before bootstrapping" >&2
         "${EXEC_CMD[@]}" "$TARGET" tedge disconnect c8y ||:
+
+        # Clear some existing state
+        # FIXME: Remove once the following are resolved
+        # * https://github.com/thin-edge/thin-edge.io/issues/2584
+        # * https://github.com/thin-edge/thin-edge.io/issues/2606
+        "${EXEC_CMD[@]}" "$TARGET" systemctl stop mosquitto tedge-agent
+        "${EXEC_CMD[@]}" "$TARGET" rm -f /var/lib/mosquitto/mosquitto.db /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl /data/mosquitto/mosquitto.db
     fi
 
     "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -7,7 +7,7 @@ WEBSITE_PAGE="device-info"
 SSH_USER=
 SCAN=${SCAN:-0}
 PATTERN="${PATTERN:-.+}"
-BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-local-ca}"
+BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-}"
 
 usage() {
     EXAMPLES=$(examples 2>&1)
@@ -15,11 +15,18 @@ usage() {
 Bootstrap a thin-edge.io device using ssh.
 The device must be reachable via ssh on the local network.
 
-The bootstrapping processes does:
+The supported bootstraping methods are described below:
 
-* Create the device certificate (if required)
-* Fetch public device certificate and upload it to Cumulocity IoT (private key does not leave the device)
-* Open the device in the Cumulocity IoT Device Management application
+Type: local-ca
+1. Create local-ca (if one does not already exist)
+2. On the device, create a CSR
+3. Sign the CSR (on the host)
+4. Copy the public certificate back to the device
+
+Type: self-signed
+1. Create the device certificate (if required)
+2. Fetch public device certificate and upload it to Cumulocity IoT (private key does not leave the device)
+3. Open the device in the Cumulocity IoT Device Management application
 
 USAGE
   c8y tedge bootstrap <TARGET> [DEVICE_ID]
@@ -123,13 +130,18 @@ done
 if [ -f .env ]; then
     echo "Loading .env file" >&2
     set -o allexport
+    # shellcheck disable=SC1091
     . .env ||:
     set +o allexport
 fi
 
-if ! command -V openssl >/dev/null 2>&1; then
-    echo "Missing dependency: openssl is not installed" >&2
-    exit 1
+# Set default bootstrap type (based on what dependencies are available)
+if [ -z "$BOOTSTRAP_TYPE" ]; then
+    if command -V openssl >/dev/null 2>&1; then
+        BOOTSTRAP_TYPE=local-ca
+    else
+        BOOTSTRAP_TYPE=self-signed
+    fi
 fi
 
 info() {
@@ -150,24 +162,30 @@ create_ca() {
     #
     # Create new ca (signing certificate)
     #
-    if [ -f "$CA_CERT_KEY" ] && [ -f "$CA_CERT_FILE" ]; then
-        echo "Using existing CA certificate. cert=$CA_CERT_FILE" >&2
-        return
-    fi
     CA_COMMON_NAME="${CA_COMMON_NAME:-"tedge-ca-$USER"}"
     CA_OU="${CA_OU:-dev}"
     CA_EXPIRE_DAYS="${CA_EXPIRE_DAYS:-365}"
 
-    # CN=mkcert reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), OU=reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), O=mkcert development CA
-    openssl req \
-        -new \
-        -x509 \
-        -days "$CA_EXPIRE_DAYS" \
-        -extensions v3_ca \
-        -nodes \
-        -subj "/O=thin-edge/OU=dev/CN=$CA_COMMON_NAME" \
-        -keyout "$CA_CERT_KEY" \
-        -out "$CA_CERT_FILE" >/dev/null 2>&1
+    if [ -f "$CA_CERT_KEY" ] && [ -f "$CA_CERT_FILE" ]; then
+        echo "Using existing CA certificate. cert=$CA_CERT_FILE" >&2
+    else
+        # CN=mkcert reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), OU=reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), O=mkcert development CA
+        openssl req \
+            -new \
+            -x509 \
+            -days "$CA_EXPIRE_DAYS" \
+            -extensions v3_ca \
+            -nodes \
+            -subj "/O=thin-edge/OU=dev/CN=$CA_COMMON_NAME" \
+            -keyout "$CA_CERT_KEY" \
+            -out "$CA_CERT_FILE" >/dev/null 2>&1
+    fi
+
+    FINGERPRINT=$(openssl x509 -fingerprint -noout -in "$CA_CERT_FILE" | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+    if c8y devicemanagement certificates get --id "$FINGERPRINT" >/dev/null 2>&1; then
+        echo "Certificate has already been uploaded to c8y. fingerprint=$FINGERPRINT" >&2
+        return
+    fi
 
     if ! c8y devicemanagement certificates create \
         -n \
@@ -179,6 +197,7 @@ create_ca() {
         echo "failed to upload device certificate" >&2
         exit 1
     fi
+    echo "Uploaded certificate" >&2
 }
 
 create_remote_cert() {
@@ -242,6 +261,7 @@ create_self_signed() {
         "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id "$DEVICE_ID" 2>/dev/null ||:
     else
         # Default to the hostname of the device
+        # shellcheck disable=SC2016
         "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id '$HOSTNAME' 2>/dev/null ||:
     fi
 
@@ -257,6 +277,12 @@ create_self_signed() {
         DEVICE_ID=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.id)
     fi
 
+    FINGERPRINT=$("${EXEC_CMD[@]}" "$TARGET" tedge cert show | grep Thumbprint | cut -d' ' -f2 | tr '[:upper:]' '[:lower:]')
+    if c8y devicemanagement certificates get --id "$FINGERPRINT" >/dev/null 2>&1; then
+        echo "Certificate has already been uploaded to c8y. fingerprint=$FINGERPRINT" >&2
+        return
+    fi
+
     echo "Certificate CN: $DEVICE_ID" >&2
     if ! c8y devicemanagement certificates create \
         -n \
@@ -268,19 +294,6 @@ create_self_signed() {
         echo "failed to upload device certificate" >&2
         exit 1
     fi
-}
-
-device_certificate_exists() {
-    target="$1"
-    DEVICE_KEY_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.key_path)
-    DEVICE_CERT_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.cert_path)
-
-    if "${EXEC_CMD[@]}" "$TARGET" test -f "$DEVICE_KEY_PATH" && "${EXEC_CMD[@]}" "$target" test -f "$DEVICE_CERT_PATH"; then
-        echo "Device certificate already exists" >&2
-        return 0
-    fi
-
-    return 1
 }
 
 get_device_id() {
@@ -345,21 +358,23 @@ do_action() {
         exit 1
     fi
 
-    if ! device_certificate_exists "$TARGET"; then
-        case "$BOOTSTRAP_TYPE" in
-                self-signed)
-                    create_self_signed
-                    ;;
-                local-ca)
-                    create_ca
-                    create_remote_cert
-                    ;;
-                *)
-                    echo "Unknown bootstrapping method" >&2
+    case "$BOOTSTRAP_TYPE" in
+            self-signed)
+                create_self_signed
+                ;;
+            local-ca)
+                if ! command -V openssl >/dev/null 2>&1; then
+                    echo "Missing dependency: openssl is not installed" >&2
                     exit 1
-                    ;;
-        esac
-    fi
+                fi
+                create_ca
+                create_remote_cert
+                ;;
+            *)
+                echo "Unknown bootstrapping method" >&2
+                exit 1
+                ;;
+    esac
 
     # Wait for certificate to be enabled
     if ! "${EXEC_CMD[@]}" "$TARGET" tedge connect c8y --test >/dev/null 2>&1; then

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -7,6 +7,7 @@ WEBSITE_PAGE="device-info"
 SSH_USER=
 SCAN=${SCAN:-0}
 PATTERN="${PATTERN:-.+}"
+BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-local-ca}"
 
 usage() {
     EXAMPLES=$(examples 2>&1)
@@ -29,13 +30,14 @@ ARGUMENTS
                       has not already been bootstrapped.
 
 FLAGS
-  --skip-website      Don't open the Cumulocity IoT Device Management application
-  --page <STRING>     Which Device Management page to open. Defaults to device-info
-  --scan              Bootstrap devices found by a scan
-  --pattern <REGEX>   Only include devices which match the given pattern (only applies when piping or scanning devices)
-  --verbose           Enable verbose logging
-  --debug             Enable debug logging
-  -h, --help          Show this help
+  --skip-website                    Don't open the Cumulocity IoT Device Management application
+  --page <STRING>                   Which Device Management page to open. Defaults to device-info
+  --type <local-ca|self-signed>     Certificate signing method. Accepts local-ca (default), self-signed
+  --scan                            Bootstrap devices found by a scan
+  --pattern <REGEX>                 Only include devices which match the given pattern (only applies when piping or scanning devices)
+  --verbose                         Enable verbose logging
+  --debug                           Enable debug logging
+  -h, --help                        Show this help
 
 $EXAMPLES
 
@@ -48,6 +50,9 @@ EXAMPLES
 
 # Bootstrap a device via ssh
 c8y tedge bootstrap root@mydevice.local
+
+# Bootstrap a device via ssh using a self signed certificate
+c8y tedge bootstrap root@mydevice.local --type self-signed
 
 # Bootstrap a device via ssh but don't open the website
 c8y tedge bootstrap root@mydevice.local --skip-website
@@ -77,6 +82,10 @@ while [ $# -gt 0 ]; do
             ;;
         --device-id)
             DEVICE_ID="$2"
+            shift
+            ;;
+        --type)
+            BOOTSTRAP_TYPE="$2"
             shift
             ;;
         --scan)
@@ -118,30 +127,115 @@ if [ -f .env ]; then
     set +o allexport
 fi
 
-EXEC_CMD=(
-    ssh
-    -n
-)
+if ! command -V openssl >/dev/null 2>&1; then
+    echo "Missing dependency: openssl is not installed" >&2
+    exit 1
+fi
 
-do_action() {
-    if [ $# -gt 0 ]; then
-        TARGET="$1"
+info() {
+    if [ "$C8Y_SETTINGS_DEFAULTS_VERBOSE" = "true" ]; then
+        printf "%s\tINFO\t%s" "$(date -Iseconds || true)" "$@" >&2
     fi
-    if [ -n "$SSH_USER" ]; then
-        TARGET="$SSH_USER@$TARGET"
-    fi
+}
 
-    # TODO: Check if the device is already connected or not, otherwise this command will fail if the url is already set.
-    # shellcheck disable=SC2029
-    URL=
-    if [ -n "$C8Y_DOMAIN" ]; then
-        URL="$C8Y_DOMAIN"
+error() {
+    printf "%s\tINFO\t%s" "$(date -Iseconds || true)" "$@" >&2
+}
+
+CA_CERT_FILE="${CA_CERT_FILE:-$HOME/tedge-ca.crt}"
+CA_CERT_KEY="${CA_CERT_KEY:-$HOME/tedge-ca.key}"
+LEAF_EXPIRE_DAYS=365
+
+create_ca() {
+    #
+    # Create new ca (signing certificate)
+    #
+    if [ -f "$CA_CERT_KEY" ] && [ -f "$CA_CERT_FILE" ]; then
+        echo "Using existing CA certificate. cert=$CA_CERT_FILE" >&2
+        return
+    fi
+    CA_COMMON_NAME="${CA_COMMON_NAME:-"tedge-ca-$USER"}"
+    CA_OU="${CA_OU:-dev}"
+    CA_EXPIRE_DAYS="${CA_EXPIRE_DAYS:-365}"
+
+    # CN=mkcert reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), OU=reubenmiller@SAG-LJWQ4P62TY (Reuben Miller), O=mkcert development CA
+    openssl req \
+        -new \
+        -x509 \
+        -days "$CA_EXPIRE_DAYS" \
+        -extensions v3_ca \
+        -nodes \
+        -subj "/O=thin-edge/OU=dev/CN=$CA_COMMON_NAME" \
+        -keyout "$CA_CERT_KEY" \
+        -out "$CA_CERT_FILE" >/dev/null 2>&1
+
+    if ! c8y devicemanagement certificates create \
+        -n \
+        --name "$CA_COMMON_NAME" \
+        --autoRegistrationEnabled \
+        --status ENABLED \
+        --file "$CA_CERT_FILE" \
+        --silentExit --silentStatusCodes 409; then
+        echo "failed to upload device certificate" >&2
+        exit 1
+    fi
+}
+
+create_remote_cert() {
+    DEVICE_KEY_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.key_path)
+    DEVICE_CERT_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.cert_path)
+
+    if ! "${EXEC_CMD[@]}" "$TARGET" test -f "$DEVICE_KEY_PATH"; then
+        info "Creating device private key"
+        "${EXEC_CMD[@]}" "$TARGET" openssl genrsa -out "$DEVICE_KEY_PATH" 2048
     else
-        URL=$(c8y sessions get --select host -o csv | sed -E 's|https?://||')
+        info "Using existing private key"
     fi
-    "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"
 
-    # Create the device certificate, ignore any errors as this could have already happened
+    # Create Certificate Signing Request (CSR)
+    DEVICE_CSR=$(
+        "${EXEC_CMD[@]}" "$TARGET" openssl req \
+            -key "$DEVICE_KEY_PATH" \
+            -new \
+            -subj "/O=thin-edge/OU=Test\ Device/CN=${DEVICE_ID}"
+    )
+
+    # Protect certificate (after csr is created)
+    "${EXEC_CMD[@]}" "$TARGET" sudo chown mosquitto:root "$DEVICE_KEY_PATH"
+    "${EXEC_CMD[@]}" "$TARGET" sudo chmod 600 "$DEVICE_KEY_PATH"
+
+    # Sign the CSR
+    CERT_EXT=$(cat << EOF
+authorityKeyIdentifier=keyid
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName=DNS:${TARGET},DNS:localhost
+EOF
+    )
+
+    DEVICE_CERT_CHAIN="/tmp/${DEVICE_ID}.crt"
+    openssl x509 -req \
+        -in <(echo "$DEVICE_CSR") \
+        -out "$DEVICE_CERT_CHAIN" \
+        -CA "$CA_CERT_FILE" \
+        -CAkey "$CA_CERT_KEY" \
+        -extfile <(echo "$CERT_EXT") \
+        -CAcreateserial \
+        -days "$LEAF_EXPIRE_DAYS"
+
+    # Build certificate chain (from leaf cert to the signing cert)
+    cat "$CA_CERT_FILE" >> "$DEVICE_CERT_CHAIN"
+
+    # Copy cert to device
+    scp "$DEVICE_CERT_CHAIN" "$TARGET:/tmp/${DEVICE_ID}.crt"
+    "${EXEC_CMD[@]}" "$TARGET" sudo mv "/tmp/${DEVICE_ID}.crt" "$DEVICE_CERT_PATH"
+    "${EXEC_CMD[@]}" "$TARGET" sudo chown mosquitto:root "$DEVICE_CERT_PATH"
+    "${EXEC_CMD[@]}" "$TARGET" sudo chmod 644 "$DEVICE_CERT_PATH"
+}
+
+create_self_signed() {
+     # Create the device certificate, ignore any errors as this could have already happened
     # Generally the device cert should not be deleted, so just fail silently for now
     if [ -n "$DEVICE_ID" ]; then
         # Use the user given device-id
@@ -173,6 +267,98 @@ do_action() {
         --silentExit --silentStatusCodes 409; then
         echo "failed to upload device certificate" >&2
         exit 1
+    fi
+}
+
+device_certificate_exists() {
+    target="$1"
+    DEVICE_KEY_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.key_path)
+    DEVICE_CERT_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.cert_path)
+
+    if "${EXEC_CMD[@]}" "$TARGET" test -f "$DEVICE_KEY_PATH" && "${EXEC_CMD[@]}" "$target" test -f "$DEVICE_CERT_PATH"; then
+        echo "Device certificate already exists" >&2
+        return 0
+    fi
+
+    return 1
+}
+
+get_device_id() {
+    # Get identity (stop on first non empty value)
+    target="$1"
+    device_id="$2"
+    _device_id_method=1
+    while [ -z "$device_id" ]; do
+        case "$_device_id_method" in
+            1)
+                # use the existing value
+                info "Trying to get identity using tedge config"
+                device_id=$("${EXEC_CMD[@]}" "$target" tedge config get device.id 2>/dev/null || true)
+                ;;
+            2)
+                # try using tedge-identity
+                info "Trying to get identity using tedge-identity"
+                device_id=$("${EXEC_CMD[@]}" "$target" tedge-identity 2>/dev/null || true)
+                ;;
+            3)
+                # hostname
+                info "Trying to get identity using hostname"
+                device_id=$("${EXEC_CMD[@]}" "$target" hostname 2>/dev/null || true)
+                ;;
+            *)
+                break
+                ;;
+        esac
+        ((_device_id_method++))
+    done
+    echo "$device_id"
+}
+
+
+EXEC_CMD=(
+    ssh
+    -n
+)
+
+do_action() {
+    if [ $# -gt 0 ]; then
+        TARGET="$1"
+    fi
+    if [ -n "$SSH_USER" ]; then
+        TARGET="$SSH_USER@$TARGET"
+    fi
+
+    # TODO: Check if the device is already connected or not, otherwise this command will fail if the url is already set.
+    # shellcheck disable=SC2029
+    URL=
+    if [ -n "$C8Y_DOMAIN" ]; then
+        URL="$C8Y_DOMAIN"
+    else
+        URL=$(c8y sessions get --select host -o csv | sed -E 's|https?://||')
+    fi
+    "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"
+
+    # Get identity
+    DEVICE_ID=$(get_device_id "$TARGET" "$DEVICE_ID")
+    if [ -z "$DEVICE_ID" ]; then
+        echo "Could not detect a device id" >&2
+        exit 1
+    fi
+
+    if ! device_certificate_exists "$TARGET"; then
+        case "$BOOTSTRAP_TYPE" in
+                self-signed)
+                    create_self_signed
+                    ;;
+                local-ca)
+                    create_ca
+                    create_remote_cert
+                    ;;
+                *)
+                    echo "Unknown bootstrapping method" >&2
+                    exit 1
+                    ;;
+        esac
     fi
 
     # Wait for certificate to be enabled
@@ -227,9 +413,18 @@ else
     DEVICES+=("$TARGET")
 fi
 
-if [ "${#DEVICES[@]}" -gt 0 ]; then
-    echo "Found ${#DEVICES[@]} devices" >&2
-fi
+
+case "${#DEVICES[@]}" in
+    0)
+        echo "No devices were found" >&2
+        ;;
+    1)
+        echo "Found ${#DEVICES[@]} device" >&2
+        ;;
+    *)
+        echo "Found ${#DEVICES[@]} devices" >&2
+        ;;
+esac
 
 for device in "${DEVICES[@]}"; do
     do_action "$device"

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -8,6 +8,7 @@ SSH_USER=
 SCAN=${SCAN:-0}
 PATTERN="${PATTERN:-.+}"
 BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-}"
+SUDO=${SUDO:-}
 
 usage() {
     EXAMPLES=$(examples 2>&1)
@@ -201,27 +202,27 @@ create_ca() {
 }
 
 create_remote_cert() {
-    DEVICE_KEY_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.key_path)
-    DEVICE_CERT_PATH=$("${EXEC_CMD[@]}" "$TARGET" tedge config get device.cert_path)
+    DEVICE_KEY_PATH=$("${EXEC_CMD[@]}" "$TARGET" $SUDO tedge config get device.key_path)
+    DEVICE_CERT_PATH=$("${EXEC_CMD[@]}" "$TARGET" $SUDO tedge config get device.cert_path)
 
     if ! "${EXEC_CMD[@]}" "$TARGET" test -f "$DEVICE_KEY_PATH"; then
         info "Creating device private key"
-        "${EXEC_CMD[@]}" "$TARGET" openssl genrsa -out "$DEVICE_KEY_PATH" 2048
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO openssl genrsa -out "$DEVICE_KEY_PATH" 2048
     else
         info "Using existing private key"
     fi
 
     # Create Certificate Signing Request (CSR)
     DEVICE_CSR=$(
-        "${EXEC_CMD[@]}" "$TARGET" openssl req \
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO openssl req \
             -key "$DEVICE_KEY_PATH" \
             -new \
             -subj "/O=thin-edge/OU=Test\ Device/CN=${DEVICE_ID}"
     )
 
     # Protect certificate (after csr is created)
-    "${EXEC_CMD[@]}" "$TARGET" sudo chown mosquitto:root "$DEVICE_KEY_PATH"
-    "${EXEC_CMD[@]}" "$TARGET" sudo chmod 600 "$DEVICE_KEY_PATH"
+    "${EXEC_CMD[@]}" "$TARGET" $SUDO chown mosquitto:root "$DEVICE_KEY_PATH"
+    "${EXEC_CMD[@]}" "$TARGET" $SUDO chmod 600 "$DEVICE_KEY_PATH"
 
     # Sign the CSR
     CERT_EXT=$(cat << EOF
@@ -258,11 +259,11 @@ create_self_signed() {
     # Generally the device cert should not be deleted, so just fail silently for now
     if [ -n "$DEVICE_ID" ]; then
         # Use the user given device-id
-        "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id "$DEVICE_ID" 2>/dev/null ||:
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge cert create --device-id "$DEVICE_ID" 2>/dev/null ||:
     else
         # Default to the hostname of the device
         # shellcheck disable=SC2016
-        "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id '$HOSTNAME' 2>/dev/null ||:
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge cert create --device-id '$HOSTNAME' 2>/dev/null ||:
     fi
 
     # Get public cert
@@ -341,6 +342,16 @@ do_action() {
         TARGET="$SSH_USER@$TARGET"
     fi
 
+    # Don't use sudo if the user is root
+    case "$TARGET" in
+        root)
+            SUDO=
+            ;;
+        *)
+            SUDO=sudo
+            ;;
+    esac
+
     # TODO: Check if the device is already connected or not, otherwise this command will fail if the url is already set.
     # shellcheck disable=SC2029
     URL=
@@ -352,21 +363,21 @@ do_action() {
 
     # Disconnect if tedge is already connected
     # Note: Check if the mapper is configured or not but it can't be assumed that it is successfully configured
-    EXISTING_C8Y_URL=$("${EXEC_CMD[@]}" "$TARGET" tedge config get c8y.url 2>/dev/null)
+    EXISTING_C8Y_URL=$("${EXEC_CMD[@]}" "$TARGET" tedge config get c8y.url 2>/dev/null ||:)
     if [ -n "$EXISTING_C8Y_URL" ]; then
         # TODO: Add option to abort if already bootstrapped (to prevent accidental)
         echo "tedge is already connected, so disconnecting before bootstrapping" >&2
-        "${EXEC_CMD[@]}" "$TARGET" tedge disconnect c8y ||:
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge disconnect c8y ||:
 
         # Clear some existing state
         # FIXME: Remove once the following are resolved
         # * https://github.com/thin-edge/thin-edge.io/issues/2584
         # * https://github.com/thin-edge/thin-edge.io/issues/2606
-        "${EXEC_CMD[@]}" "$TARGET" systemctl stop mosquitto tedge-agent
-        "${EXEC_CMD[@]}" "$TARGET" rm -f /var/lib/mosquitto/mosquitto.db /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl /data/mosquitto/mosquitto.db
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO systemctl stop mosquitto tedge-agent
+        "${EXEC_CMD[@]}" "$TARGET" $SUDO rm -f /var/lib/mosquitto/mosquitto.db /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl /data/mosquitto/mosquitto.db
     fi
 
-    "${EXEC_CMD[@]}" "$TARGET" tedge config set c8y.url "$URL"
+    "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge config set c8y.url "$URL"
 
     # Get identity
     DEVICE_ID=$(get_device_id "$TARGET" "$DEVICE_ID")
@@ -394,14 +405,14 @@ do_action() {
     esac
 
     # Wait for certificate to be enabled
-    if ! "${EXEC_CMD[@]}" "$TARGET" tedge connect c8y --test >/dev/null 2>&1; then
+    if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge connect c8y --test >/dev/null 2>&1; then
         sleep 2
 
         attempt=0
         max_attempts=10
         success=0
         while [ "$attempt" -lt "$max_attempts" ]; do
-            if "${EXEC_CMD[@]}" "$TARGET" tedge connect c8y; then
+            if "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge connect c8y; then
                 success=1
                 break
             fi


### PR DESCRIPTION
`c8y tedge bootstrap` now uses a local CA by default to bootstrap the device.

Using a local ca by default has significant advantages as it does not require uploading one certificate per device, instead only the CA certificate needs to be uploaded once to  Cumulocity and the device certs are only signed locally by the CA. This results in less load on Cumulocity and is closer to a production setup (except that the local ca is on your own machine instead of part of a PKI)

**Example**

Bootstrap a device using a locally signed ca (the ca certificate will be created automatically on your machine if it does not yet already exist)

```
c8y tedge bootstrap root@mydevice.local
```

Or if you really want to (but it is not recommended), you can switch back to the self-signed certificates using:

```
c8y tedge bootstrap root@mydevice.local --type self-signed
```