### PR TITLE
fix(bootstrap): set PATH when executing remote ssh command to avoid command not found errors

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -768,6 +768,12 @@ remote_scp() {
 
 SCP_CMD=remote_scp
 
+# NOTE: Some SSH services (like dropbear) don't inherit the PATH variable, so it results in some false
+# negatives when tedge tries to detect the mosquitto version, e.g.:
+#   Failed to detect mosquitto version: assuming mosquitto version < 2.0.0
+#
+REMOTE_PATH="PATH=\$PATH:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 do_action() {
     if [ $# -gt 0 ]; then
         TARGET="$1"
@@ -853,14 +859,14 @@ do_action() {
             esac
         fi
         # Wait for certificate to be enabled
-        if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge connect c8y --test >/dev/null 2>&1; then
+        if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO PATH="$REMOTE_PATH" tedge connect c8y --test >/dev/null 2>&1; then
             sleep 2
 
             attempt=0
             max_attempts=10
             success=0
             while [ "$attempt" -lt "$max_attempts" ]; do
-                if "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge reconnect c8y; then
+                if "${EXEC_CMD[@]}" "$TARGET" $SUDO PATH="$REMOTE_PATH" tedge reconnect c8y; then
                     success=1
                     break
                 fi


### PR DESCRIPTION
When running the bootstrap on some Yocto builds, the remote ssh command does not inherit the expected `PATH` variable, which results in the `tedge connect c8y` command erroneously thinking that a mosquitto version < 2.0.0 is being used. This has a knock-on affect as it does not configure the `localsession_clean` option for the bridge configuration (resulting in losing MQTT message on startup).

For example, if 

```sh
% ssh root@rpi4-d83add90fe56.local -- mosquitto --help
sh: line 1: mosquitto: command not found
```

But by explicitly setting the `PATH` variable to some sensible defaults, then it has a chance to find mosquitto under `/usr/sbin`

```sh
% ssh root@rpi4-d83add90fe56.local -- PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin mosquitto --help
mosquitto version 2.0.18

mosquitto is an MQTT v5.0/v3.1.1/v3.1 broker.

Usage: mosquitto [-c config_file] [-d] [-h] [-p port]

 -c : specify the broker config file.
 -d : put the broker into the background after starting.
 -h : display this help.
 -p : start the broker listening on the specified port.
      Not recommended in conjunction with the -c option.
 -v : verbose mode - enable all logging types. This overrides
      any logging options given in the config file.

See https://mosquitto.org/ for more information.
```

I suspect that the root cause is some missing sshd config in the Yocto build however it is a bit difficult to pin-point for now.
