### PR TITLE
feat: new commands to quickly launch a tedge-demo-container

### DIFF
--- a/commands/demo/list
+++ b/commands/demo/list
@@ -29,4 +29,7 @@ done
 
 PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
 export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+
+echo "Existing demos under: $PROJECT_DIR" >&2
+
 ls -c1 "$PROJECT_DIR"

--- a/commands/demo/list
+++ b/commands/demo/list
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+usage() {
+    cat <<EOT >&2
+List the existing tedge-container-demo instances
+
+c8y tedge demo list
+
+Examples
+
+  c8y tedge demo list
+  # List all existing demos
+
+EOT
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
+export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+ls -c1 "$PROJECT_DIR"

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -e
+
+usage() {
+    cat <<EOT >&2
+Start a new tedge-container-demo instance
+
+It will download the latest docker-compose from the https://github.com/thin-edge/tedge-demo-container repository
+and bootstrap it using your current go-c8y-cli session.
+
+c8y tedge demo start <DEVICE_NAME>
+
+Examples
+
+  c8y tedge demo start mydevice001
+  # Start a tedge-container-demo using the device name 'mydevice001'
+
+EOT
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -lt 1 ]; then
+    fail "Missing device name (aka project name)"
+fi
+NAME="$1"
+shift
+
+COMPOSE_URL="https://raw.githubusercontent.com/thin-edge/tedge-demo-container/main/demos/docker-compose/device/docker-compose.yaml"
+PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
+export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+
+mkdir -p "$PROJECT_DIR"
+
+echo "Downloading the docker-compose.yaml file" >&2
+if command -V wget >/dev/null 2>&1; then
+    wget -q -O - "$COMPOSE_URL" > "$COMPOSE_FILE"
+elif command -V curl >/dev/null 2>&1; then
+    curl -LSs "$COMPOSE_URL" > "$COMPOSE_FILE"
+else
+    fail "Missing required dependencies: Either curl or wget is needed"
+fi
+
+echo "Running docker compose up -d" >&2
+(cd "$PROJECT_DIR" && docker compose up -d)
+
+echo "Bootstrapping" >&2
+c8y tedge bootstrap-container tedge "$NAME" "$@"

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -45,6 +45,7 @@ COMPOSE_URL="https://raw.githubusercontent.com/thin-edge/tedge-demo-container/ma
 PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
 export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
 
+echo "Creating demo folder: $PROJECT_DIR" >&2
 mkdir -p "$PROJECT_DIR"
 
 echo "Downloading the docker-compose.yaml file" >&2

--- a/commands/demo/stop
+++ b/commands/demo/stop
@@ -42,7 +42,7 @@ PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
 export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
 
 if [ ! -f "$COMPOSE_FILE" ]; then
-    echo "Project does not exist" >&2
+    echo "Demo does not exist (under $PROJECT_DIR)" >&2
     exit 0
 fi
 

--- a/commands/demo/stop
+++ b/commands/demo/stop
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+
+usage() {
+    cat <<EOT >&2
+Stop an existing tedge-container-demo instance
+
+c8y tedge demo stop <DEVICE_NAME>
+
+Examples
+
+  c8y tedge demo stop mydevice001
+  # Stop an dmeo instance with the device name 'mydevice001'
+
+EOT
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -lt 1 ]; then
+    fail "Missing device name (aka project name)"
+fi
+NAME="$1"
+shift
+
+PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
+export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Project does not exist" >&2
+    exit 0
+fi
+
+(cd "$PROJECT_DIR" && docker compose down -v)
+rm -rf "$PROJECT_DIR"


### PR DESCRIPTION
Simple commands to start, stop and list tedge-demo-containers.

Mainly because I was tired of constantly looking at the [tedge-demo-container](https://github.com/thin-edge/tedge-demo-container) instructions when I wanted to quickly spawn an instance for testing something against a new tenant.

**Start an instance (including bootstrapping)**

```sh
c8y tedge demo start mydevice001
```

**List existing demo instances**

```sh
c8y tedge demo list
```

**Stop/delete a demo instance**

```sh
c8y tedge demo stop mydevice001
```