### PR TITLE
feat(bootstrap): support bootstrapping in offline mode (new in thin-edge.io 1.1.0)

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -733,6 +733,28 @@ configure_mtls_mqtt_client() {
     "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge config set mqtt.client.auth.key_file "$LOCAL_CERT_KEY"
 }
 
+c8y_bulk_registration() {
+    EXTERNAL_ID="$1"
+    DEVICE_TYPE="thin-edge.io"
+    if [ $# -gt 1 ]; then
+        DEVICE_TYPE="$2"
+    fi
+
+    REG_FILE="/tmp/${EXTERNAL_ID}.csv"
+
+    cat << EOT > "$REG_FILE"
+"ID","AUTH_TYPE","TYPE","NAME","com_cumulocity_model_Agent.active"
+"$EXTERNAL_ID",CERTIFICATES,"$DEVICE_TYPE","$EXTERNAL_ID",true
+EOT
+
+    echo "Manually registering device: $EXTERNAL_ID (type=$DEVICE_TYPE)" >&2
+    if ! c8y api POST devicecontrol/bulkNewDeviceRequests --file "$REG_FILE" --force; then
+        echo "Warning: Failed to manually register device (via c8y bulk registration API): $EXTERNAL_ID" >&2
+        exit 1
+    fi
+    rm -f "$REG_FILE"
+}
+
 get_device_id() {
     # Get identity (stop on first non empty value)
     target="$1"
@@ -870,6 +892,10 @@ do_action() {
         # In offline mode, just configure the bridge, do not test the connection as the device may not have internet
         if [ "$OFFLINE_MODE" = 1 ]; then
             echo "Bootstrapping thin-edge.io in OFFLINE mode" >&2
+
+            # Register device via c8y bulk registration api because "tedge connect c8y" doesn't do it
+            c8y_bulk_registration "$DEVICE_ID"
+
             if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO PATH="$REMOTE_PATH" tedge connect c8y --offline; then
                 echo "Offline mode requires thin-edge.io >= 1.1.0. Please upgrade and try again" >&2
                 exit 1

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -12,6 +12,7 @@ SCAN=${SCAN:-0}
 PATTERN="${PATTERN:-.+}"
 BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-}"
 SUDO=${SUDO:-}
+OFFLINE_MODE=${OFFLINE_MODE:-0}
 
 usage() {
     EXAMPLES=$(examples 2>&1)
@@ -63,6 +64,7 @@ FLAGS
   --main-device <MAIN_DEVICE>       Main device hostname or ip address to connect to via ssh. This is only used when enabling mTLS on a child device.
   --scan                            Bootstrap devices found by a scan
   --pattern <REGEX>                 Only include devices which match the given pattern (only applies when piping or scanning devices)
+  --offline                         Use offline mode where the cloud connection will not be checked. Ideal if your device does not have internet access
   --verbose                         Enable verbose logging
   --debug                           Enable debug logging
   -h, --help                        Show this help
@@ -78,6 +80,9 @@ EXAMPLES
 
 # Bootstrap a device via ssh
 c8y tedge bootstrap root@mydevice.local
+
+# Bootstrap a device via ssh in offline mode (if your device does not have internet access)
+c8y tedge bootstrap root@mydevice.local --offline
 
 # Bootstrap a device via ssh using a self signed certificate
 c8y tedge bootstrap root@mydevice.local --type self-signed
@@ -139,6 +144,9 @@ while [ $# -gt 0 ]; do
         --ssh-user)
             SSH_USER="$2"
             shift
+            ;;
+        --offline)
+            OFFLINE_MODE=1
             ;;
         --verbose|-v)
             export C8Y_SETTINGS_DEFAULTS_VERBOSE="true"
@@ -858,6 +866,17 @@ do_action() {
                         ;;
             esac
         fi
+
+        # In offline mode, just configure the bridge, do not test the connection as the device may not have internet
+        if [ "$OFFLINE_MODE" = 1 ]; then
+            echo "Bootstrapping thin-edge.io in OFFLINE mode" >&2
+            if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO PATH="$REMOTE_PATH" tedge connect c8y --offline; then
+                echo "Offline mode requires thin-edge.io >= 1.1.0. Please upgrade and try again" >&2
+                exit 1
+            fi
+            exit 0
+        fi
+
         # Wait for certificate to be enabled
         if ! "${EXEC_CMD[@]}" "$TARGET" $SUDO PATH="$REMOTE_PATH" tedge connect c8y --test >/dev/null 2>&1; then
             sleep 2


### PR DESCRIPTION
Offline bootstrapping means that the cloud connection will not be tested on the device. Only use if the device does not have an internet connection.

In offline mode, the `tedge connect c8y` will not create the device in Cumulocity IoT (as it does not have connectivity to do so), therefore the bootstrap process will include registering the device using the [Cumulocity IoT Bulk Registration API](https://cumulocity.com/api/core/2024/#operation/postBulkNewDeviceRequestCollectionResource).

The typical offline bootstrapping process is as follows:

1. Connect device (to be bootstrapped) to a network without internet connectivity (e.g. local network)
2. Connect your laptop (which is calling the bootstrapping) to the internet, and the local network (where the device is)
3. Run the bootstrapping command
    ```
    c8y tedge bootstrap root@mydevice

    # or sometimes the IP address is more reliable if you have problems with the mdns address
    c8y tedge bootstrap root@192.168.1.xxx
    ```

    **Notes**
    
    * After this step, the device will have been manually registered to Cumulocity IoT, so you will see a device in the Device Management UI, however it will only have very basic information (name, type) as the device is yet to connect directly to Cumulocity IoT (where the additional information is then published)

4. Connect the device to a network with internet connectivity

5. Verify the device in the UI (you may need to reload the UI if you don't see all the expected tabs)

**Warning** This feature requires thin-edge.io 1.1.0 to work (where the `tedge connect <cloud> --offline` support was added).

**Example**

```sh
c8y tedge bootstrap root@mydevice.local --offline
```

*Output*

```
Using user provided device
Found 1 device
tedge is already connected, so disconnecting before bootstrapping
Removing Cumulocity bridge.

Applying changes to mosquitto.

Cumulocity Bridge successfully disconnected!

Stopping tedge-mapper-c8y service.

Disabling tedge-mapper-c8y service.

tedge-mapper-c8y service successfully stopped and disabled!

Using existing CA certificate. cert=/Users/myuser/tedge-ca.crt
Certificate has already been uploaded to c8y. fingerprint=abcdef91f2eada0d04b3cc3c79e6f329d07b11a9
Certificate request self-signature ok
subject=O=thin-edge, OU=Test Device, CN=mydevice
mydevice.crt                                                                                                                                                                                              100% 2356    78.6KB/s   00:00
Bootstrapping thin-edge.io in OFFLINE mode
Checking if systemd is available.

Detected mosquitto version >= 2.0.0
Checking if configuration for requested bridge already exists.

Validating the bridge certificates.

Offline mode. Skipping device creation in Cumulocity cloud.

Saving configuration for requested bridge.

Restarting mosquitto service.

Awaiting mosquitto to start. This may take up to 5 seconds.

Enabling mosquitto service on reboots.

Successfully created bridge connection!

Offline mode. Skipping connection check.

Checking if tedge-mapper is installed.

Starting tedge-mapper-c8y service.

Persisting tedge-mapper-c8y on reboot.

tedge-mapper-c8y service successfully started and enabled!

Enabling software management.

Checking if tedge-agent is installed.

Starting tedge-agent service.

Persisting tedge-agent on reboot.

tedge-agent service successfully started and enabled!
```

