### PR TITLE
feat(demo): add shell command to open an interactive shell to the demo container

### DIFF
--- a/commands/demo/shell
+++ b/commands/demo/shell
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -e
+
+usage() {
+    cat <<EOT >&2
+Open an interactive shell to an existing tedge-container-demo instance
+
+c8y tedge demo shell <DEVICE_NAME>
+
+Examples
+
+  c8y tedge demo shell mydevice001
+  # Open a shell to the demo with device name 'mydevice001'
+
+EOT
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -lt 1 ]; then
+    fail "Missing device name (aka project name)"
+fi
+NAME="$1"
+shift
+
+PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
+export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Demo does not exist (under $PROJECT_DIR)" >&2
+    exit 0
+fi
+
+(cd "$PROJECT_DIR" && docker compose exec tedge bash)


### PR DESCRIPTION
Extend the demo commands to also support opening up an interactive shell, so it is easier to explore thin-edge.io.

**Example**

```sh
# Start a demo
c8y tedge demo start mydevice001

# open a shell in the demo container
c8y tedge demo shell mydevice001
```