### PR TITLE
feat(bootstrap): check for invalid flags and throw an error if detected

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -153,6 +153,11 @@ while [ $# -gt 0 ]; do
         --skip-renew-cert)
             RENEW_CERT=0
             ;;
+        --*|-*)
+            printf '\nERROR: Unknown flag. %s\n\n' "$1" >&2
+            usage
+            exit 1
+            ;;
         *)
             if [ -z "$TARGET" ]; then
                 TARGET="$1"

--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -99,6 +99,11 @@ while [ $# -gt 0 ]; do
             set -x
             export C8Y_SETTINGS_DEFAULTS_DEBUG="true"
             ;;
+        --*|-*)
+            printf '\nERROR: Unknown flag. %s\n\n' "$1" >&2
+            usage
+            exit 1
+            ;;
         *)
             if [ -z "$TARGET" ]; then
                 TARGET="$1"

--- a/commands/scan
+++ b/commands/scan
@@ -54,6 +54,11 @@ while [ $# -gt 0 ]; do
             PATTERN="$2"
             shift
             ;;
+        --*|-*)
+            printf '\nERROR: Unknown flag. %s\n\n' "$1" >&2
+            usage
+            exit 1
+            ;;
         *)
             if [ -z "$TIMEOUT" ]; then
                 TIMEOUT="${1:-2}"


### PR DESCRIPTION
Throw an error if the user provides unknown flags. This prevents unknown flags from being interpreted as positional arguments.

This typically happens if they are using newly added flags, but they are still running the old version of the extension where the flag is not recognized, and in this case the flag was being interpreted as positional arguments.