### PR TITLE
fix: bind the tls listener to 0.0.0.0

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -693,7 +693,7 @@ configure_mtls_mqtt_broker() {
     ## As a workaround the configuration for external settings is created independently without `tedge`
 
     cat << EOF >"/tmp/${DEVICE_ID}-tls-listener.conf"
-listener 8883 ${TARGET_IP}
+listener 8883 0.0.0.0
 allow_anonymous false
 require_certificate true
 use_identity_as_username true


### PR DESCRIPTION
Avoid problems with the mosquitto TLS listener when the public ip address is not available on the device itself (e.g. this occurs when using a VM in Azure)