### PR TITLE
feat(bootstrap-container): avoid prompting user when uploading device certificate

### DIFF
--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -288,7 +288,8 @@ do_action() {
         --autoRegistrationEnabled \
         --status ENABLED \
         --file <(echo "$PUBLIC_CERT") \
-        --silentExit --silentStatusCodes 409; then
+        --silentExit --silentStatusCodes 409 \
+        --force; then
         echo "failed to upload device certificate" >&2
         exit 1
     fi


### PR DESCRIPTION
In `c8y tedge bootstrap-container`, the uploading of the device certificate no longer prompts for confirmation to reduce the time to spin up the demo.

For example, the following prompt is no longer presented to the user:

```
? Confirm (job: 1)
Upload trusted device certificate on tenant t9679
[y] Yes  [a] Yes to All  [n] No  [l] No to All y
```