### PR TITLE
feat: support debug mode via env variable DEBUG

### DIFF
--- a/commands/demo/list
+++ b/commands/demo/list
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "${DEBUG:-}" = 1 ]; then
+    set -x
+fi
+
 usage() {
     cat <<EOT >&2
 List the existing tedge-container-demo instances

--- a/commands/demo/shell
+++ b/commands/demo/shell
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "${DEBUG:-}" = 1 ]; then
+    set -x
+fi
+
 usage() {
     cat <<EOT >&2
 Open an interactive shell to an existing tedge-container-demo instance

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "${DEBUG:-}" = 1 ]; then
+    set -x
+fi
+
 usage() {
     cat <<EOT >&2
 Start a new tedge-container-demo instance

--- a/commands/demo/stop
+++ b/commands/demo/stop
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "${DEBUG:-}" = 1 ]; then
+    set -x
+fi
+
 usage() {
     cat <<EOT >&2
 Stop an existing tedge-container-demo instance


### PR DESCRIPTION
The `c8y tedge demo` commands can be debugged (e.g. enabling `set -x`) by setting the `DEBUG` env variable.

**Example**

```sh
DEBUG=1 c8y tedge bootstrap start mydevice001
```