### PR TITLE
fix(bootstrap-container): support reading the DEVICE_ID from the target container

### DIFF
--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -279,7 +279,8 @@ do_action() {
         "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id "$DEVICE_ID" 2>/dev/null ||:
     else
         # Default to the hostname of the device
-        "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id '${HOSTNAME:-$HOST}' 2>/dev/null ||:
+        # shellcheck disable=SC2016
+        "${EXEC_CMD[@]}" "$TARGET" tedge cert create --device-id '${DEVICE_ID:-tedge_$(hostname)}' 2>/dev/null ||:
     fi
 
     # Get public cert

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -65,7 +65,7 @@ echo "Running docker compose up -d" >&2
 (cd "$PROJECT_DIR" && docker compose up -d)
 
 echo "Bootstrapping" >&2
-c8y tedge bootstrap-container tedge "$NAME" "$@"
+c8y tedge bootstrap-container tedge --device-id "$NAME" "$@"
 
 # Create a default remoteaccess configuration but only if the user has the correct permissions
 MO_ID=$(c8y identity get -n --name "$NAME" --select managedObject.id -o csv)


### PR DESCRIPTION
Previously the logic would only check if the `DEVICE_ID` env variable was set on the host and not the target device.