### PR TITLE
fix(bootstrap): load .env file before parsing flags to allow flags to override given env variables

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -102,6 +102,16 @@ c8y tedge bootstrap --ssh-user root --scan --pattern "rpi3"
 EOT
 }
 
+# Load .env automatically
+# Load before parsing arguments so that explicit flags can override any set values
+if [ -f .env ]; then
+    echo "Loading .env file" >&2
+    set -o allexport
+    # shellcheck disable=SC1091
+    . .env ||:
+    set +o allexport
+fi
+
 #
 # Parse args
 #
@@ -175,15 +185,6 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
-
-# Load .env automatically
-if [ -f .env ]; then
-    echo "Loading .env file" >&2
-    set -o allexport
-    # shellcheck disable=SC1091
-    . .env ||:
-    set +o allexport
-fi
 
 # Set default bootstrap type (based on what dependencies are available)
 if [ -z "$BOOTSTRAP_TYPE" ]; then

--- a/commands/bootstrap-container
+++ b/commands/bootstrap-container
@@ -64,6 +64,16 @@ c8y tedge bootstrap-container container01
 EOT
 }
 
+# Load .env automatically so it plays nicely with docker compose which also does this
+# Load before parsing arguments so that explicit flags can override any set values
+if [ -f .env ]; then
+    echo "Loading .env file" >&2
+    set -o allexport
+    # shellcheck disable=SC1091
+    . .env ||:
+    set +o allexport
+fi
+
 #
 # Parse args
 #
@@ -113,14 +123,6 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
-
-# Load .env automatically so it plays nicely with docker compose which also does this
-if [ -f .env ]; then
-    echo "Loading .env file" >&2
-    set -o allexport
-    . .env ||:
-    set +o allexport
-fi
 
 # Try auto detecting container cli (based on what is available)
 if [ -z "$C8Y_TEDGE_CONTAINER_CLI" ]; then


### PR DESCRIPTION
In practice explicit values provided by command line arguments should be taken over any environment variables