### PR TITLE
fix(scan): only print non empty results

### DIFF
--- a/commands/scan
+++ b/commands/scan
@@ -116,4 +116,4 @@ scan_tedge() {
     scan_tedge "_tedge._tcp" &
     scan_tedge "_thin-edge_mqtt._tcp" &
     wait
-} | sort | uniq
+} | sort | uniq | grep -v "^$"


### PR DESCRIPTION
Filter out any empty scan results.

**Before**

```sh
% c8y tedge scan

rpi4-aaaaaa.local
rpi5-bbbb.local
```

**After**

```sh
% c8y tedge scan
rpi4-aaaaaa.local
rpi5-bbbb.local
```