### PR TITLE
feat(bootstrap): don't prompt user when uploading certificate to c8y

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -273,6 +273,7 @@ create_ca() {
 
     if ! c8y devicemanagement certificates create \
         -n \
+        --force \
         --name "$CA_COMMON_NAME" \
         --autoRegistrationEnabled \
         --status ENABLED \
@@ -395,6 +396,7 @@ create_self_signed() {
     echo "Certificate CN: $DEVICE_ID" >&2
     if ! c8y devicemanagement certificates create \
         -n \
+        --force \
         --name "$DEVICE_ID" \
         --autoRegistrationEnabled \
         --status ENABLED \


### PR DESCRIPTION
Don't prompt the user when uploading a device certificate or intermediate certificate to Cumulocity as it disrupts the user workflow, and the user has already opted into running the bootstrap function.