### PR TITLE
feat(demo-start): allow users to skip container bootstrapping

### DIFF
--- a/commands/demo/start
+++ b/commands/demo/start
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 FEATURES="${FEATURES:-}"
+BOOTSTRAP="${BOOTSTRAP:-1}"
 
 if [ "${DEBUG:-}" = 1 ]; then
     set -x
@@ -19,6 +20,7 @@ c8y tedge demo start [DEVICE_NAME] [--features <pki|nopki>]
 Arguments
 
   --features <feature_set>      List of features to activate. e.g. nopki
+  --skip-bootstrap              Don't bootstrap the demo setup
 
 Examples
 
@@ -39,7 +41,7 @@ fail() {
     exit 1
 }
 
-POSITIONAL_ARGS=
+POSITIONAL_ARGS=()
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -51,15 +53,20 @@ while [ $# -gt 0 ]; do
             usage
             exit 0
             ;;
+        --skip-bootstrap)
+            BOOTSTRAP=0
+            ;;
         *)
-            POSITIONAL_ARGS=" $POSITIONAL_ARGS"
+            POSITIONAL_ARGS+=("$1")
             ;;
     esac
     shift
 done
 
-# shellcheck disable=SC2086
-set -- $POSITIONAL_ARGS
+# Only set if rest arguments are defined
+if [ "${#POSITIONAL_ARGS[@]}" -gt 0 ]; then
+    set -- "${POSITIONAL_ARGS[@]}"
+fi
 
 if [ $# -gt 0 ]; then
     NAME="$1"
@@ -92,6 +99,19 @@ fi
 
 echo "Running docker compose up -d" >&2
 (cd "$PROJECT_DIR" && docker compose up -d)
+
+if [ "$BOOTSTRAP" = 0 ]; then
+    cat <<EOT >&2
+
+Skipping bootstrapping. You are on your own now ;)
+
+You can open a shell on the device using:
+
+  c8y tedge demo shell '$NAME'
+
+EOT
+    exit 0
+fi
 
 echo "Bootstrapping" >&2
 c8y tedge bootstrap-container tedge --device-id "$NAME" "$@"


### PR DESCRIPTION
Support option to skip bootstrapping to allow users to experiment with manual bootstrapping.

**Example**

```
c8y tedge demo start mydevice001 --skip-bootstrap
```