### PR TITLE
fix(bootstrap): remove misleading log statement about tedge already being connected

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -919,8 +919,9 @@ do_action() {
         if [ "$RENEW_CERT" = 0 ] && [ "$IS_CONNECTED" = 1 ]; then
             echo "tedge is already connected, skipping certificate generation" >&2
         else
-            echo "tedge is already connected, so disconnecting before bootstrapping" >&2
+            # ensure that tedge is disconnected before setting url and generating new certificate
             "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge disconnect c8y ||:
+            echo "Setting tedge c8y.url to $URL" >&2
             "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge config set c8y.url "$URL"
 
             case "$BOOTSTRAP_TYPE" in


### PR DESCRIPTION
Remove the misleading log statement shown to the user when bootstrapping a new device.

The log message about disconnect tedge has been removed as this was not correct and provides no additional information to the user (as the tedge disconnect command already provides some outut).

Instead just a simple log statement about setting the c8y.url config has been included.