### PR TITLE
feat(demo start): auto generate device name if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ c8y extension install thin-edge/c8y-tedge
 
 ## Examples
 
+### Start a demo container
+
+Start a demo container using a randomly generated device name:
+
+```sh
+c8y tedge demo start
+```
+
+Or you can specify the device name to be used:
+
+```
+c8y tedge demo start tedge0001
+```
+
 ### Bootstrap device via ssh
 
 Bootstrap a thin-edge.io enable device using SSH.

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -12,9 +12,12 @@ Start a new tedge-container-demo instance
 It will download the latest docker-compose from the https://github.com/thin-edge/tedge-demo-container repository
 and bootstrap it using your current go-c8y-cli session.
 
-c8y tedge demo start <DEVICE_NAME>
+c8y tedge demo start [DEVICE_NAME]
 
 Examples
+
+  c8y tedge demo start
+  # Start a tedge-container-demo using a randomly generated device name
 
   c8y tedge demo start mydevice001
   # Start a tedge-container-demo using the device name 'mydevice001'
@@ -39,11 +42,13 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ $# -lt 1 ]; then
-    fail "Missing device name (aka project name)"
+if [ $# -gt 0 ]; then
+    NAME="$1"
+    shift
+else
+    NAME=$(c8y template execute --template "'tedge_' + _.Hex(8)")
+    echo "Using randomly generated device name: $NAME" >&2
 fi
-NAME="$1"
-shift
 
 COMPOSE_URL="https://raw.githubusercontent.com/thin-edge/tedge-demo-container/main/demos/docker-compose/device/docker-compose.yaml"
 PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"


### PR DESCRIPTION
Don't force users to supply a device name, instead if it is not provided, then use an auto generated device name.

```sh
c8y tedge demo start

# Or specify (the current behaviour)
c8y tedge demo start device001
```