### PR TITLE
feat: add local-ca management commands

### DIFF
--- a/commands/local-ca/create
+++ b/commands/local-ca/create
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -e
+NAME=${NAME:-}
+CA_EXPIRE_DAYS="${CA_EXPIRE_DAYS:-730}"
+CA_OU="${CA_OU:-dev}"
+OVERWRITE="${OVERWRITE:-0}"
+
+usage() {
+    EXAMPLES=$(examples 2>&1)
+    cat << EOT >&2
+Create a local CA certificate used to sign device certificates
+
+USAGE
+  c8y tedge local-ca create [NAME]
+
+ARGUMENTS
+  NAME                Name of the signing certificate
+
+FLAGS
+  --expires <DAYS>                  Number of days the CA certificate should be valid for
+  --overwrite                       Overwrite any existing certificates
+  --verbose                         Enable verbose logging
+  --debug                           Enable debug logging
+  --examples                        Shows examples
+  -h, --help                        Show this help
+
+$EXAMPLES
+
+EOT
+}
+
+examples() {
+    cat << EOT >&2
+EXAMPLES
+
+# Create a local CA certificate (using the default value)
+c8y tedge local-ca create
+
+# Create a local CA certificate using a given name
+c8y tedge local-ca create dev
+
+EOT
+}
+
+#
+# Parse args
+#
+POSITIONAL_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+    
+        --examples)
+            examples
+            exit 0
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --expires)
+            CA_EXPIRE_DAYS="$2"
+            shift
+            ;;
+        --ca-ou)
+            CA_OU="$2"
+            shift
+            ;;
+        --overwrite)
+            OVERWRITE=1
+            ;;
+        --verbose|-v)
+            export C8Y_SETTINGS_DEFAULTS_VERBOSE="true"
+            ;;
+        --debug)
+            set -x
+            export C8Y_SETTINGS_DEFAULTS_DEBUG="true"
+            ;;
+        --*|-*)
+            printf '\nERROR: Unknown flag. %s\n\n' "$1" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+    esac
+    shift
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
+if [ $# -eq 0 ]; then
+    NAME="tedge-ca-$(whoami)"
+else
+    NAME="$1"
+fi
+
+CA_CERT_FILE="${CA_CERT_FILE:-$HOME/$NAME.crt}"
+CA_CERT_KEY="${CA_CERT_KEY:-$HOME/$NAME.key}"
+
+
+create_ca() {
+    name="$1"
+    #
+    # Create new ca (signing certificate)
+    #
+    if [ "$OVERWRITE" = 1 ]; then
+        rm -f "$CA_CERT_KEY"
+        rm -f "$CA_CERT_FILE"
+    fi
+
+    if [ -f "$CA_CERT_KEY" ] && [ -f "$CA_CERT_FILE" ]; then
+        echo "Using existing CA certificate. cert=$CA_CERT_FILE" >&2
+    else
+        openssl req \
+            -new \
+            -x509 \
+            -days "$CA_EXPIRE_DAYS" \
+            -extensions v3_ca \
+            -nodes \
+            -subj "/O=thin-edge/OU=${CA_OU}/CN=${name}" \
+            -keyout "$CA_CERT_KEY" \
+            -out "$CA_CERT_FILE" >/dev/null 2>&1
+    fi
+
+    FINGERPRINT=$(openssl x509 -fingerprint -noout -in "$CA_CERT_FILE" | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+    if c8y devicemanagement certificates get --id "$FINGERPRINT" >/dev/null 2>&1; then
+        echo "Certificate has already been uploaded to c8y. fingerprint=$FINGERPRINT" >&2
+        return
+    fi
+
+    if ! c8y devicemanagement certificates create \
+        -n \
+        --force \
+        --name "$name" \
+        --autoRegistrationEnabled \
+        --status ENABLED \
+        --file "$CA_CERT_FILE" \
+        --silentExit --silentStatusCodes 409; then
+        echo "failed to upload CA certificate" >&2
+        exit 1
+    fi
+    echo "Uploaded certificate" >&2
+
+    echo
+    echo "  private key: $CA_CERT_KEY"
+    echo "  public key:  $CA_CERT_FILE"
+    echo
+}
+
+create_ca "$NAME"

--- a/commands/local-ca/sign
+++ b/commands/local-ca/sign
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -e
+CA_NAME="${CA_NAME:-}"
+LEAF_EXPIRE_DAYS="${LEAF_EXPIRE_DAYS:-365}"
+
+usage() {
+    EXAMPLES=$(examples 2>&1)
+    cat << EOT >&2
+Sign a device certificate using a local CA certificate which was created
+by the "c8y tedge local-ca create" command
+
+USAGE
+  c8y tedge local-ca sign <CSR_FILE>
+
+ARGUMENTS
+  CSR_FILE                File path to the Certificate Signing Request
+
+FLAGS
+  --ca-name <NAME>                  CA certificate name (created via the 'c8y tedge local-ca create' command)
+  --expires <DAYS>                  Number of days the CA certificate should be valid for
+  --verbose                         Enable verbose logging
+  --debug                           Enable debug logging
+  --examples                        Shows examples
+  -h, --help                        Show this help
+
+$EXAMPLES
+
+EOT
+}
+
+examples() {
+    cat << EOT >&2
+EXAMPLES
+
+# Sign a device CSR using the default local CA certificate
+c8y tedge local-ca sign ./device.csr
+
+# Sign a device CSR using a local-ca called "dev" (created via "c8y tedge local-ca create dev")
+c8y tedge local-ca sign ./device.csr --ca-name dev
+
+EOT
+}
+
+#
+# Parse args
+#
+POSITIONAL_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+    
+        --examples)
+            examples
+            exit 0
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --expires)
+            LEAF_EXPIRE_DAYS="$2"
+            shift
+            ;;
+        --ca-name)
+            CA_NAME="$2"
+            shift
+            ;;
+        --verbose|-v)
+            export C8Y_SETTINGS_DEFAULTS_VERBOSE="true"
+            ;;
+        --debug)
+            set -x
+            export C8Y_SETTINGS_DEFAULTS_DEBUG="true"
+            ;;
+        --*|-*)
+            printf '\nERROR: Unknown flag. %s\n\n' "$1" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+    esac
+    shift
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
+if [ -z "$CA_NAME" ]; then
+    CA_NAME="tedge-ca-$(whoami)"
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Error. Missing required argument" >&2
+    usage
+    exit 1  
+fi
+DEVICE_CSR="$1"
+
+CA_CERT_FILE="${CA_CERT_FILE:-$HOME/$CA_NAME.crt}"
+CA_CERT_KEY="${CA_CERT_KEY:-$HOME/$CA_NAME.key}"
+
+sign_csr() {
+    csr_file="$1"
+    CERT_EXT=$(cat << EOF
+authorityKeyIdentifier=keyid
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+    )
+
+    DEVICE_CERT_CHAIN="${csr_file}.tmp"
+    openssl x509 -req \
+        -in <(cat "$csr_file") \
+        -out "$DEVICE_CERT_CHAIN" \
+        -CA "$CA_CERT_FILE" \
+        -CAkey "$CA_CERT_KEY" \
+        -extfile <(echo "$CERT_EXT") \
+        -CAcreateserial \
+        -days "$LEAF_EXPIRE_DAYS"
+
+    # Build certificate chain (from leaf cert to the signing cert)
+    cat "$CA_CERT_FILE" >> "$DEVICE_CERT_CHAIN"
+
+    # output to stdout
+    cat "$DEVICE_CERT_CHAIN"
+    rm -f "$DEVICE_CERT_CHAIN"
+}
+
+sign_csr "$DEVICE_CSR"


### PR DESCRIPTION
Enable some local-ca management command to help manually sign leaf device certificates (useful for interactions with HSMs like Yubikeys).

**Examples**

```sh
# Create a default local-ca and upload to c8y
c8y tedge local-ca create

# Sign a CSR (writing the certificate to stdout) using the pre-existing local certificate
c8y tedge local-ca sign ./device.csr
```