### PR TITLE
fix(demo start): open website only after creating the remote access config

### DIFF
--- a/commands/demo/start
+++ b/commands/demo/start
@@ -3,6 +3,7 @@ set -e
 
 FEATURES="${FEATURES:-}"
 BOOTSTRAP="${BOOTSTRAP:-1}"
+OPEN_WEBSITE="${OPEN_WEBSITE:-1}"
 
 if [ "${DEBUG:-}" = 1 ]; then
     set -x
@@ -21,6 +22,7 @@ Arguments
 
   --features <feature_set>      List of features to activate. e.g. nopki
   --skip-bootstrap              Don't bootstrap the demo setup
+  --skip-website                Don't open Cumulocity webpage
 
 Examples
 
@@ -52,6 +54,9 @@ while [ $# -gt 0 ]; do
         --help|-h)
             usage
             exit 0
+            ;;
+        --skip-website)
+            OPEN_WEBSITE=0
             ;;
         --skip-bootstrap)
             BOOTSTRAP=0
@@ -114,7 +119,7 @@ EOT
 fi
 
 echo "Bootstrapping" >&2
-c8y tedge bootstrap-container tedge --device-id "$NAME" "$@"
+c8y tedge bootstrap-container tedge --device-id "$NAME" --skip-website "$@"
 
 # Create a default remoteaccess configuration but only if the user has the correct permissions
 MO_ID=$(c8y identity get -n --name "$NAME" --select managedObject.id -o csv)
@@ -146,4 +151,9 @@ if [ -n "$MO_ID" ]; then
         echo "Warning: We couldn't add the remote access configuration as you don't have the required permissions"
         echo "To fix this: Add the 'Remote Access' permission to a role like 'Admin' and assign yourself to it"
     fi
+fi
+
+# open the page after remote access configuration has been created
+if [ "$OPEN_WEBSITE" = 1 ]; then
+    c8y applications open --device "$MO_ID" --application devicemanagement
 fi


### PR DESCRIPTION
Only open the Cumulocity Device Management application after the remote access configuration has been added so that the user does not have to reload the webpage manually.