### PR TITLE
feat: create a remote access passthrough configuration for native ssh and populate the authorized keys if any local public keys are found

### DIFF
--- a/commands/demo/start
+++ b/commands/demo/start
@@ -147,6 +147,26 @@ if [ -n "$MO_ID" ]; then
                 --hostname "127.0.0.1" \
                 --port "2812" \
                 --force >/dev/null
+
+        # Add passthrough connection to demo a native ssh connection
+        # It will copy the users public keys into the authorized keys for the iotadmin user (same used for webssh)
+        c8y remoteaccess configurations get -n --id native-ssh --device "$MO_ID" --silentStatusCodes 404 ||
+            c8y remoteaccess configurations create-passthrough \
+                -n \
+                --device "$MO_ID" \
+                --name "native-ssh" \
+                --hostname "127.0.0.1" \
+                --port 22 \
+                --force >/dev/null
+
+        # Copy the host's public keys to the container demo container for a password-less experience
+        if [ -d "$HOME/.ssh" ]; then
+            AUTHORIZED_KEYS=$(cat "$HOME/.ssh"/*.pub 2>/dev/null ||:)
+            if [ -n "$AUTHORIZED_KEYS" ]; then
+                echo "Adding ssh authorized_keys to iotadmin user" >&2
+                (cd "$PROJECT_DIR" && docker compose exec tedge sh -c "mkdir -p /home/iotadmin/.ssh; echo \"$AUTHORIZED_KEYS\" >/home/iotadmin/.ssh/authorized_keys; chown -R iotadmin:iotadmin /home/iotadmin/.ssh" )
+            fi
+        fi
     else
         echo "Warning: We couldn't add the remote access configuration as you don't have the required permissions"
         echo "To fix this: Add the 'Remote Access' permission to a role like 'Admin' and assign yourself to it"


### PR DESCRIPTION
Improve the Cloud Remote Access passthrough feature by pre-configuring the demo container with native SSH.

The user's public ssh keys will also be copied to the authorized_keys file under the `iotadmin` user in the container, so that users can enjoy an out-of-the-box experience using go-c8y-cli.

After the container is started, users can connect to it using:

```sh
c8y remoteaccess connect ssh --device rmi_with_keys --user iotadmin
```

Note: If the user is not using an ssh agent, then they might still be prompted for the password as a suitable ssh key might not be found. In this case, the ssh client should prompt the user for a password instead.