### PR TITLE
feat(bootstrap): support bootstrapping with Cumulocity certificate authority

### DIFF
--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -13,6 +13,7 @@ PATTERN="${PATTERN:-.+}"
 BOOTSTRAP_TYPE="${BOOTSTRAP_TYPE:-}"
 SUDO=${SUDO:-}
 OFFLINE_MODE=${OFFLINE_MODE:-0}
+ONE_TIME_PASSWORD=${ONE_TIME_PASSWORD:-}
 REMOVE_KNOWN_HOST_ENTRY_ON_FAILURE=${REMOVE_KNOWN_HOST_ENTRY_ON_FAILURE:-1}
 
 usage() {
@@ -22,7 +23,7 @@ Bootstrap a thin-edge.io device using ssh. thin-edge.io will be installed on the
 if it is not already present.
 The device must be reachable via ssh on the local network.
 
-The supported bootstraping methods are described below:
+The supported bootstrapping methods are described below:
 
 Type: local-ca
 1. Create local-ca (if one does not already exist)
@@ -62,6 +63,8 @@ FLAGS
   --skip-website                           Don't open the Cumulocity IoT Device Management application
   --page <STRING>                          Which Device Management page to open. Defaults to device-info
   --type <local-ca|self-signed|c8y-ca|auto>     Certificate signing method. Accepts local-ca, self-signed, auto (default)
+  --one-time-password, -p                  One-time password for the Cumulocity certificate-authority bootstrap type.
+                                           A random password will be used if one is not provided.
   --mtls                                   Enable mTLS for all local connections over MQTT and HTTP
   --main-device <MAIN_DEVICE>              Main device hostname or ip address to connect to via ssh. This is only used when enabling mTLS on a child device.
   --scan                                   Bootstrap devices found by a scan
@@ -85,6 +88,9 @@ c8y tedge bootstrap root@mydevice.local
 
 # Bootstrap a device via ssh and forcing the usage of the Cumulocity Certificate Authority (it must already be enabled)
 c8y tedge bootstrap root@mydevice.local --type c8y-ca
+
+# Bootstrap a device via ssh, using Cumulocity Certificate Authority and with a user defined one-time password
+c8y tedge bootstrap root@mydevice.local --type c8y-ca --one-time-password "ex7s23j4c7687234lk;jO"
 
 # Bootstrap a device via ssh in offline mode (if your device does not have internet access)
 c8y tedge bootstrap root@mydevice.local --offline
@@ -141,6 +147,11 @@ while [ $# -gt 0 ]; do
             ;;
         --type)
             BOOTSTRAP_TYPE="$2"
+            shift
+            ;;
+        --one-time-password|-p)
+            # Only used for Cumulocity CA
+            ONE_TIME_PASSWORD="$2"
             shift
             ;;
         --mtls)
@@ -447,7 +458,9 @@ register_with_c8y_ca() {
     # Delete in case if the registration already exists
     c8y deviceregistration delete --id "$DEVICE_ID" --force >/dev/null 2>&1 ||:
 
-    ONE_TIME_PASSWORD=$(c8y template execute --template "_.PasswordUrlSafe(31)")
+    if [ -z "$ONE_TIME_PASSWORD" ]; then
+        ONE_TIME_PASSWORD=$(c8y template execute --template "_.PasswordUrlSafe(31)")
+    fi
     c8y deviceregistration register-ca --id "$DEVICE_ID" --one-time-password "$ONE_TIME_PASSWORD"
     "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge cert download c8y --device-id "$DEVICE_ID" --one-time-password "$ONE_TIME_PASSWORD" --retry-every 5s --max-timeout 30s  2>/dev/null ||:
 }

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -58,18 +58,18 @@ ARGUMENTS
                       has not already been bootstrapped.
 
 FLAGS
-  --skip-renew-cert                 Don't update the certificate of an already connected device
-  --skip-website                    Don't open the Cumulocity IoT Device Management application
-  --page <STRING>                   Which Device Management page to open. Defaults to device-info
-  --type <local-ca|self-signed>     Certificate signing method. Accepts local-ca (default), self-signed
-  --mtls                            Enable mTLS for all local connections over MQTT and HTTP
-  --main-device <MAIN_DEVICE>       Main device hostname or ip address to connect to via ssh. This is only used when enabling mTLS on a child device.
-  --scan                            Bootstrap devices found by a scan
-  --pattern <REGEX>                 Only include devices which match the given pattern (only applies when piping or scanning devices)
-  --offline                         Use offline mode where the cloud connection will not be checked. Ideal if your device does not have internet access
-  --verbose                         Enable verbose logging
-  --debug                           Enable debug logging
-  -h, --help                        Show this help
+  --skip-renew-cert                        Don't update the certificate of an already connected device
+  --skip-website                           Don't open the Cumulocity IoT Device Management application
+  --page <STRING>                          Which Device Management page to open. Defaults to device-info
+  --type <local-ca|self-signed|c8y-ca|auto>     Certificate signing method. Accepts local-ca, self-signed, auto (default)
+  --mtls                                   Enable mTLS for all local connections over MQTT and HTTP
+  --main-device <MAIN_DEVICE>              Main device hostname or ip address to connect to via ssh. This is only used when enabling mTLS on a child device.
+  --scan                                   Bootstrap devices found by a scan
+  --pattern <REGEX>                        Only include devices which match the given pattern (only applies when piping or scanning devices)
+  --offline                                Use offline mode where the cloud connection will not be checked. Ideal if your device does not have internet access
+  --verbose                                Enable verbose logging
+  --debug                                  Enable debug logging
+  -h, --help                               Show this help
 
 $EXAMPLES
 
@@ -82,6 +82,9 @@ EXAMPLES
 
 # Bootstrap a device via ssh
 c8y tedge bootstrap root@mydevice.local
+
+# Bootstrap a device via ssh and forcing the usage of the Cumulocity Certificate Authority (it must already be enabled)
+c8y tedge bootstrap root@mydevice.local --type c8y-ca
 
 # Bootstrap a device via ssh in offline mode (if your device does not have internet access)
 c8y tedge bootstrap root@mydevice.local --offline
@@ -195,14 +198,35 @@ if [ $# -ge 2 ]; then
     DEVICE_ID="$2"
 fi
 
-# Set default bootstrap type (based on what dependencies are available)
-if [ -z "$BOOTSTRAP_TYPE" ]; then
-    if command -V openssl >/dev/null 2>&1; then
-        BOOTSTRAP_TYPE=local-ca
-    else
-        BOOTSTRAP_TYPE=self-signed
+supports_c8y_ca() {
+    target="$1"
+    ENABLED=$(c8y features get --key certificate-authority --select active -o csv ||:)
+    if [ "$ENABLED" != true ]; then
+        return 1
     fi
-fi
+
+    if ! "${EXEC_CMD[@]}" "$target" tedge cert download c8y --help >/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+detect_bootstrap_type() {
+    TARGET="$1"
+    # Set default bootstrap type (based on what dependencies are available)
+    if [ -z "$BOOTSTRAP_TYPE" ] || [ "$BOOTSTRAP_TYPE" = auto ]; then
+        if supports_c8y_ca "$TARGET"; then
+            BOOTSTRAP_TYPE=c8y-ca
+        elif command -V openssl >/dev/null 2>&1; then
+            BOOTSTRAP_TYPE=local-ca
+        else
+            BOOTSTRAP_TYPE=self-signed
+        fi
+
+        echo "Using bootstrap type: $BOOTSTRAP_TYPE" >&2
+    fi
+}
+
 
 info() {
     if [ "$C8Y_SETTINGS_DEFAULTS_VERBOSE" = "true" ]; then
@@ -406,6 +430,20 @@ create_self_signed() {
         echo "failed to upload device certificate" >&2
         exit 1
     fi
+}
+
+register_with_c8y_ca() {
+    # Register the device using the Cumulocity certificate-authority feature
+    if [ -z "$DEVICE_ID" ]; then
+        DEVICE_ID=$("${EXEC_CMD[@]}" "$TARGET" $SUDO tedge cert create --device-id '$HOSTNAME' 2>/dev/null ||:)
+    fi
+
+    # Delete in case if the registration already exists
+    c8y deviceregistration delete --id "$DEVICE_ID" --force >/dev/null 2>&1 ||:
+
+    ONE_TIME_PASSWORD=$(c8y template execute --template "_.PasswordUrlSafe(31)")
+    c8y deviceregistration register-ca --id "$DEVICE_ID" --one-time-password "$ONE_TIME_PASSWORD"
+    "${EXEC_CMD[@]}" "$TARGET" $SUDO tedge cert download c8y --device-id "$DEVICE_ID" --one-time-password "$ONE_TIME_PASSWORD" --retry-every 5s --max-timeout 30s  2>/dev/null ||:
 }
 
 # Create a signing certificate for a main device
@@ -897,6 +935,7 @@ do_action() {
 
     # Install thin-edge.io
     install_tedge_if_missing
+    detect_bootstrap_type "$TARGET"
 
     # Get identity
     DEVICE_ID=$(get_device_id "$TARGET" "$DEVICE_ID")
@@ -946,6 +985,12 @@ do_action() {
                         fi
                         create_ca
                         create_remote_cert
+                        ;;
+                    c8y-ca)
+                        if ! register_with_c8y_ca; then
+                            echo "Failed to register device with the Cumulocity Certificate Authority" >&2
+                            exit 1
+                        fi
                         ;;
                     *)
                         echo "Unknown bootstrapping method" >&2

--- a/commands/bootstrap
+++ b/commands/bootstrap
@@ -205,6 +205,12 @@ supports_c8y_ca() {
         return 1
     fi
 
+    # Apply minimum Cumulocity platform version check
+    if [ -z "$(c8y currenttenant version --filter "value version >2025.129.0")" ]; then
+        echo "INFO: Cumulocity version must be >2025.129.0 to use the certificate-authority feature" >&2
+        return 1
+    fi
+
     if ! "${EXEC_CMD[@]}" "$target" tedge cert download c8y --help >/dev/null 2>&1; then
         return 1
     fi


### PR DESCRIPTION
Support bootstrapping a device using the Cumulocity PUBLIC_PREVIEW feature, certificate-authority.

By default, the bootsrap command will try to auto detect whether the Certificate Authority feature is available for usage, otherwise it will fallback to using a local CA (which is the previous default).

Below shows some of the usages:

```
# Use c8y-ca if available otherwise using the local-ca
c8y tedge bootstrap root@example.local

# Force usage of local CA
c8y tedge bootstrap root@example.local --type local-ca

# Force usage of Cumulocity CA
c8y tedge bootstrap root@example.local --type c8y-ca
```