### PR TITLE
feat(demo): use zsh when opening a shell inside the demo

### DIFF
--- a/commands/demo/shell
+++ b/commands/demo/shell
@@ -50,4 +50,4 @@ if [ ! -f "$COMPOSE_FILE" ]; then
     exit 0
 fi
 
-(cd "$PROJECT_DIR" && docker compose exec tedge bash)
+(cd "$PROJECT_DIR" && docker compose exec tedge zsh)


### PR DESCRIPTION
zsh is now used by default (instead of bash) when running `c8y tedge demo shell <name>`, as zsh provides improved tab completion over bash.