### PR TITLE
fix(demo): ignore errors if the device user does not exist when stopping the demo

### DIFF
--- a/commands/demo/stop
+++ b/commands/demo/stop
@@ -73,6 +73,6 @@ rm -rf "$PROJECT_DIR"
 # Delete the device from Cumulocity
 if [ "$KEEP_DEVICE" != 1 ]; then
     echo "Removing device and related device user. externalId=$NAME" >&2
-    c8y identity get -n --name "$NAME" | c8y devices delete --cascade --force >/dev/null ||:
-    c8y users delete --id "device_$NAME" --force >/dev/null ||:
+    c8y identity get -n --name "$NAME" --silentExit --silentStatusCodes 404,403,401 | c8y devices delete --cascade --force >/dev/null ||:
+    c8y users delete --id "device_$NAME" --silentExit --silentStatusCodes 404,403,401 --force >/dev/null ||:
 fi


### PR DESCRIPTION
Ignore any errors when stopping the demo container (e.g. `c8y tedge demo stop <name>`) and the device user does not exist in the platform. This avoids some noise on the console when the container has not been bootstrapped, or the users context has changed since starting the container.
