### PR TITLE
fix: fix reference to randomly generated name in the log message

### DIFF
--- a/commands/container-bundle/start
+++ b/commands/container-bundle/start
@@ -131,7 +131,7 @@ if [ $# -gt 0 ]; then
     shift
 else
     DEVICE_ID=$(c8y template execute --template "'tedge_' + _.Hex(8)")
-    echo "Using randomly generated device name: $NAME" >&2
+    echo "Using randomly generated device name: $DEVICE_ID" >&2
 fi
 
 # Try auto detecting container cli (based on what is available)


### PR DESCRIPTION
Fix a minor bug where the incorrect variable was referenced in the log message:

```
$ c8y tedge container-bundle start --ca self-signed
Using randomly generated device name:
```