### PR TITLE
feat(demo list): show project state running or stopped

### DIFF
--- a/commands/demo/list
+++ b/commands/demo/list
@@ -85,6 +85,10 @@ echo "Existing demos under: $BASE_PROJECT_DIR" >&2
     # get tedge version
     TEDGE_VERSION=$(cd "$PROJECT_DIR" && $DOCKER_CMD compose -f "$COMPOSE_FILE" exec tedge tedge --version 2>/dev/null | cut -d' ' -f2- ||:)
 
-    printf '{"name":"%s","url":"%s","tedgeVersion":"%s"}\n' "$NAME" "${URL:-"-"}" "$TEDGE_VERSION"
+    STATE="stopped"
+    if [ -n "$TEDGE_VERSION" ]; then
+        STATE="running"
+    fi
+    printf '{"name":"%s","state":"%s","url":"%s","tedgeVersion":"%s"}\n' "$NAME" "$STATE" "${URL:-"-"}" "${TEDGE_VERSION:-"-"}"
 done
-) | C8Y_SETTINGS_VIEWS_COLUMNPADDING=20 c8y util show --select name,tedgeVersion,url
+) | C8Y_SETTINGS_VIEWS_COLUMNPADDING=20 c8y util show --select name,state,tedgeVersion,url


### PR DESCRIPTION
In the `c8y tedge demo list`, include the demo's running state so that users can tell if it is running or not (though the tedge version and url will only be shown if the demo is running.

**Example**

```sh
$ c8y tedge demo list
Existing demos under: /Users/example/.tedge/tedge-demo-container
| name             | state        | tedgeVersion   | url              |
|------------------|--------------|----------------|------------------|
| tedge_1.7.0      | stopped      | -              | -                |
| rmi_tedge0001    | running      | 1.7.1          | https://example… |
```