### PR TITLE
fix(demo start): use compose start rather than up if the project already exists

### DIFF
--- a/commands/demo/start
+++ b/commands/demo/start
@@ -124,8 +124,8 @@ export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
 # Just start the project if it already exists
 if [ -f "$COMPOSE_FILE" ]; then
     echo "Project already exists: path=$PROJECT_DIR" >&2
-    echo "Running docker compose up -d" >&2
-    (cd "$PROJECT_DIR" && $DOCKER_CMD compose -f "$COMPOSE_FILE" up -d)
+    echo "Running docker compose start" >&2
+    (cd "$PROJECT_DIR" && $DOCKER_CMD compose -f "$COMPOSE_FILE" start)
     exit 0
 fi
 


### PR DESCRIPTION
Use `docker compose start` (or the equivalent) when starting an already existing project instead of `up`. This avoids overriding an existing info and avoids pulling in the new containers images.