### PR TITLE
feat(demo): include c8y.url in list commands even when the containers aren't running

### DIFF
--- a/commands/container-bundle/list
+++ b/commands/container-bundle/list
@@ -51,7 +51,23 @@ echo "Using container cli: $C8Y_TEDGE_CONTAINER_CLI" >&2
 
 echo "Existing tedge-container-bundle instances (label=c8y.tedge.container.bundle=1)" >&2
 
-CONTAINER_NAMES=$($C8Y_TEDGE_CONTAINER_CLI container list -a --filter "label=c8y.tedge.container.bundle=1" --format="{{.Names}},{{.State}}" | sed 's|^/||g')
+# jsonnet template to extract container info including the c8y.url which is stored in the label
+JSONNET_TEMPLATE='
+{
+  State: input.value.State,
+  Name: std.strReplace(input.value.Names, "/", ""),
+  url: std.join("," , [
+      std.splitLimit(x,"=",1)[1]
+      for x in std.split(input.value.Labels,",")
+      if std.startsWith(x, "c8y.url=")
+    ]
+  ),
+}
+'
+CONTAINER_NAMES=$(
+    $C8Y_TEDGE_CONTAINER_CLI container list -a --filter "label=c8y.tedge.container.bundle=1" --format='{{. | json}}' \
+    | c8y template execute --template "$JSONNET_TEMPLATE" --output csv --select "Name,State,url"
+)
 
 if [ -z "$CONTAINER_NAMES" ]; then
     echo "No tedge-container-bundles instances exist" >&2
@@ -64,12 +80,16 @@ fi
 
         NAME=$(echo "$CONTAINER_INFO" | cut -d, -f1)
         STATE=$(echo "$CONTAINER_INFO" | cut -d, -f2)
+        URL_FROM_LABEL=$(echo "$CONTAINER_INFO" | cut -d, -f3)
 
         # get tedge config
         CONFIG=$("$C8Y_TEDGE_CONTAINER_CLI" exec "$NAME" tedge config list 2>/dev/null ||:)
         URL=$(echo "$CONFIG" | grep c8y.http | head -n1 | cut -d= -f2 | cut -d: -f1)
         if [ -z "$URL" ]; then
             URL=$(echo "$CONFIG" | grep c8y.url | head -n1 | cut -d= -f2 | cut -d: -f1)
+        fi
+        if [ -z "$URL" ] && [ -n "$URL_FROM_LABEL" ]; then
+            URL="$URL_FROM_LABEL"
         fi
         if [ -n "$URL" ]; then
             URL="https://$URL"

--- a/commands/container-bundle/start
+++ b/commands/container-bundle/start
@@ -366,9 +366,14 @@ case "$AUTH_TYPE" in
         ;;
 esac
 
+if [ -z "$C8Y_DOMAIN" ]; then
+    C8Y_DOMAIN=$(c8y currenttenant get -n --select domainName -o csv)
+fi
+
 RUN_OPTIONS=(
     # Add label identify container launched by c8y-tedge
     --label "c8y.tedge.container.bundle=1"
+    --label "c8y.url=$C8Y_DOMAIN"
 )
 
 if [ "$C8Y_TEDGE_CONTAINER_CLI" = docker ]; then
@@ -378,9 +383,6 @@ if [ "$C8Y_TEDGE_CONTAINER_CLI" = docker ]; then
     )
 fi
 
-if [ -z "$C8Y_DOMAIN" ]; then
-    C8Y_DOMAIN=$(c8y currenttenant get -n --select domainName -o csv)
-fi
 
 port() {
     # return a port with a given offset to try

--- a/commands/demo/list
+++ b/commands/demo/list
@@ -71,6 +71,7 @@ echo "Existing demos under: $BASE_PROJECT_DIR" >&2
     NAME="$(basename "$PROJECT_DIR")"
 
     COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+    C8Y_URL_FILE="$PROJECT_DIR/c8y.url"
 
     # get tedge config
     CONFIG=$(cd "$PROJECT_DIR" && $DOCKER_CMD compose -f "$COMPOSE_FILE" exec tedge tedge config list 2>/dev/null ||:)
@@ -78,6 +79,12 @@ echo "Existing demos under: $BASE_PROJECT_DIR" >&2
     if [ -z "$URL" ]; then
         URL=$(echo "$CONFIG" | grep c8y.url | head -n1 | cut -d= -f2 | cut -d: -f1)
     fi
+
+    if [ -z "$URL" ] && [ -f "$C8Y_URL_FILE" ]; then
+        # use value from file as the container is not running so the configured value can not be read
+        URL=$(cat "$C8Y_URL_FILE")
+    fi
+
     if [ -n "$URL" ]; then
         URL="https://$URL"
     fi

--- a/commands/demo/start
+++ b/commands/demo/start
@@ -120,6 +120,7 @@ fi
 COMPOSE_URL="https://raw.githubusercontent.com/thin-edge/tedge-demo-container/main/demos/docker-compose/device/docker-compose.yaml"
 PROJECT_DIR="$HOME/.tedge/tedge-demo-container/$NAME"
 export COMPOSE_FILE="$PROJECT_DIR/docker-compose.yaml"
+C8Y_URL_FILE="$PROJECT_DIR/c8y.url"
 
 # Just start the project if it already exists
 if [ -f "$COMPOSE_FILE" ]; then
@@ -180,6 +181,11 @@ fi
 
 echo "Bootstrapping" >&2
 c8y tedge bootstrap-container tedge --device-id "$NAME" --skip-website --auth-type "$AUTH_TYPE" "$@"
+
+if [ -n "$C8Y_DOMAIN" ]; then
+    # store the configured c8y.url to file so it can be looked up in the list command (when the container is not running)
+    echo "$C8Y_DOMAIN" > "$C8Y_URL_FILE" ||:
+fi
 
 check_c8y_role() {
     # check if the current user has a given Cumulocity Role


### PR DESCRIPTION
Add a mechanism to retrieve the c8y.url from the demo container, and container-bundle when the demo is not running.